### PR TITLE
Add support for vcpkg as external package provider.

### DIFF
--- a/repos/plywood/scripts/bootstrap_CMakeLists.txt
+++ b/repos/plywood/scripts/bootstrap_CMakeLists.txt
@@ -469,6 +469,7 @@ SetSourceFolders(BUILD-PROVIDER_SOURCES "${SRC_FOLDER}build/provider/ply-build-p
     "impl/PackageManager_Conan.cpp"
     "impl/PackageManager_Homebrew.cpp"
     "impl/PackageManager_MacPorts.cpp"
+    "impl/PackageManager_Vcpkg.cpp"
 )
 add_library(build-provider OBJECT
     ${BUILD-PROVIDER_SOURCES}

--- a/repos/plywood/src/build/provider/ply-build-provider/HostTools.h
+++ b/repos/plywood/src/build/provider/ply-build-provider/HostTools.h
@@ -15,6 +15,7 @@ struct HostTools {
     PLY_BUILD_ENTRY PackageManager* getConan() const;
     PLY_BUILD_ENTRY PackageManager* getMacPorts() const;
     PLY_BUILD_ENTRY PackageManager* getHomebrew() const;
+    PLY_BUILD_ENTRY PackageManager* getVcpkg() const;
 
     PLY_BUILD_ENTRY static Owned<HostTools> instance_;
 

--- a/repos/plywood/src/build/provider/ply-build-provider/impl/PackageManager_Vcpkg.cpp
+++ b/repos/plywood/src/build/provider/ply-build-provider/impl/PackageManager_Vcpkg.cpp
@@ -1,0 +1,55 @@
+/*------------------------------------
+  ///\  Plywood C++ Framework
+  \\\/  https://plywood.arc80.com/
+------------------------------------*/
+#include <ply-build-common/Core.h>
+#include <ply-build-provider/PackageManager.h>
+#include <ply-build-provider/HostTools.h>
+
+namespace ply {
+namespace build {
+
+#if PLY_TARGET_WIN32
+struct PackageManager_Vcpkg : PackageManager {
+    bool isPackageInstalled(StringView packageName) override {
+        Owned<Subprocess> sub = Subprocess::exec("vcpkg", {"list", packageName}, {},
+                                                 Subprocess::Output::openStdOutOnly());
+        if (!sub)
+            return false;
+        Owned<StringReader> sr = TextFormat::platformPreference().createImporter(
+            Owned<InStream>::create(sub->readFromStdOut.borrow()));
+        bool anyLines = false;
+        while (String line = sr->readString<fmt::Line>()) {
+            anyLines = true;
+        }
+        return (anyLines && sub->join() == 0);
+    }
+
+    String getInstallPrefix(StringView) override {
+        return "$(VcpkgCurrentInstalledDir)";
+    }
+
+    bool installPackage(StringView packageName) override {
+        Owned<Subprocess> sub =
+            Subprocess::exec("vcpkg", {"install", packageName}, {}, Subprocess::Output::inherit(),
+                             Subprocess::Input::inherit());
+        return (sub && sub->join() == 0);
+    }
+};
+#endif
+
+PLY_NO_INLINE PackageManager* HostTools::getVcpkg() const {
+#if PLY_TARGET_WIN32
+    static Owned<PackageManager_Vcpkg> vcpkg = [] {
+        Owned<Subprocess> sub =
+            Subprocess::exec("vcpkg", {"version"}, {}, Subprocess::Output::ignore());
+        return (sub && sub->join() == 0) ? new PackageManager_Vcpkg : nullptr;
+    }();
+    return vcpkg;
+#else
+    return nullptr;
+#endif
+}
+
+} // namespace build
+} // namespace ply

--- a/repos/plywood/src/build/repo/ply-build-repo/PackageProvider.cpp
+++ b/repos/plywood/src/build/repo/ply-build-repo/PackageProvider.cpp
@@ -23,6 +23,8 @@ PLY_NO_INLINE ExternResult PackageProvider::handle(ExternCommand cmd,
         pkgMan = HostTools::get()->getHomebrew();
     } else if (this->manager == Manager::MacPorts) {
         pkgMan = HostTools::get()->getMacPorts();
+    } else if (this->manager == Manager::Vcpkg) {
+        pkgMan = HostTools::get()->getVcpkg();
     }
 
     if (!pkgMan) {

--- a/repos/plywood/src/build/repo/ply-build-repo/PackageProvider.h
+++ b/repos/plywood/src/build/repo/ply-build-repo/PackageProvider.h
@@ -14,6 +14,7 @@ struct PackageProvider {
         Apt,
         MacPorts,
         Homebrew,
+        Vcpkg,
     };
 
     Manager manager;


### PR DESCRIPTION
Initial work on adding `vcpkg`.  Example usage in .modules.cpp

```cpp
// [ply extern="glfw" provider="vcpkg"]
ExternResult extern_glfw_prebuilt(ExternCommand cmd, ExternProviderArgs* args) {
  PackageProvider prov{
      PackageProvider::Vcpkg, "glfw3", [&](StringView prefix) {
        String triplet = args->toolchain->arch + "-windows";
        args->dep->includeDirs.append(NativePath::join(prefix, triplet, "include"));
        args->dep->libs.append(NativePath::join(prefix, triplet, "lib\\glfw3dll.lib"));
      }};
  return prov.handle(cmd, args);
}
```

vcpkg has more options like static libraries, debug/release and x86/x86_64 and adding that selection logic in the .modules.cpp file doesn't seem user friendly.  I think making the PackageProvider's aware of arch, build type, etc. would be beneficial here.