### PR TITLE
Add support for files not participating in the build

### DIFF
--- a/repos/plywood/scripts/Helper.cmake
+++ b/repos/plywood/scripts/Helper.cmake
@@ -100,6 +100,30 @@ macro(SetSourceFolders varName root)
     endforeach()
 endmacro()
 
+macro(SetNonParticipatingFiles varName root)
+    foreach(relFile ${ARGN})
+        set(absFile "${root}/${relFile}")
+        get_filename_component(fileExt "${absFile}" EXT)
+        # Skip natvis files on platforms that don't support them.
+        if(fileExt STREQUAL ".natvis")
+            if (NOT MSVC)
+                continue()
+            endif()
+        endif()
+
+        list(APPEND "${varName}" "${absFile}")
+        get_filename_component(folder "${relFile}" PATH)
+        string(REPLACE / \\ folder "${folder}")
+        source_group("${folder}" FILES "${absFile}")
+
+        # Make sure c/cpp files are not compiled.
+        set(CPP_EXTENSIONS .c .cpp)
+        if(NOT fileExt STREQUAL ".natvis")
+            set_source_files_properties("${absFile}" PROPERTIES HEADER_FILE_ONLY TRUE)
+        endif()
+    endforeach()
+endmacro()
+
 macro(SetPrecompiledHeader targetName sourceListVarName generatorSource pchHeader pchFile)
     if(MSVC)
         foreach(absFile ${${sourceListVarName}})

--- a/repos/plywood/src/build/repo/ply-build-repo/ModuleArgs.cpp
+++ b/repos/plywood/src/build/repo/ply-build-repo/ModuleArgs.cpp
@@ -29,6 +29,12 @@ PLY_NO_INLINE void ModuleArgs::addSourceFilesWhenImported(StringView sourceRoot,
     this->buildTarget->addSourceFilesWhenImported(absSourceRoot, relPaths);
 }
 
+PLY_BUILD_ENTRY void ModuleArgs::addNonParticipatingFiles(StringView sourceRoot,
+                                                          ArrayView<const StringView> relPaths) {
+    String absSourceRoot = NativePath::join(this->targetInst->instantiatorPath, sourceRoot);
+    this->buildTarget->addNonParticipatingFiles(absSourceRoot, relPaths);
+}
+
 PLY_NO_INLINE void ModuleArgs::setPrecompiledHeader(StringView generatorSource,
                                                     StringView pchInclude) {
     String absGeneratorSource =

--- a/repos/plywood/src/build/repo/ply-build-repo/ModuleArgs.h
+++ b/repos/plywood/src/build/repo/ply-build-repo/ModuleArgs.h
@@ -24,6 +24,8 @@ struct ModuleArgs {
     PLY_BUILD_ENTRY void addSourceFiles(StringView sourcePath, bool recursive = true);
     PLY_BUILD_ENTRY void addSourceFilesWhenImported(StringView sourceRoot,
                                                     ArrayView<const StringView> relPaths);
+    PLY_BUILD_ENTRY void addNonParticipatingFiles(StringView sourceRoot,
+                                                  ArrayView<const StringView> relPaths);
     PLY_BUILD_ENTRY void setPrecompiledHeader(StringView generatorSource, StringView pchInclude);
     PLY_BUILD_ENTRY void addTarget(Visibility visibility, StringView targetName);
     PLY_BUILD_ENTRY void addExtern(Visibility visibility, StringView externName);

--- a/repos/plywood/src/build/target/ply-build-target/CMakeLists.cpp
+++ b/repos/plywood/src/build/target/ply-build-target/CMakeLists.cpp
@@ -90,6 +90,19 @@ include("${CMAKE_CURRENT_LIST_DIR}/Helper.cmake")
             *outs << ")\n";
         }
 
+        for (const BuildTarget::SourceFilesPair& sfPair : buildTarget->nonParticipatingFiles) {
+            String varName = uniqueTargetName.upperAsc() + "_SOURCES";
+            if (find(sourceVarNames, varName) < 0)
+                sourceVarNames.append(varName);
+
+            outs->format("SetNonParticipatingFiles({} \"{}\"\n", varName,
+                         fmt::EscapedString(filterPath(sfPair.root)));
+            for (StringView relPath : sfPair.relFiles) {
+                outs->format("    \"{}\"\n", fmt::EscapedString(filterPath(relPath)));
+            }
+            *outs << ")\n";
+        }
+
         // Add this target
         BuildTargetType targetType = buildTarget->targetType;
         switch (targetType) {

--- a/repos/plywood/src/build/target/ply-build-target/Dependency.h
+++ b/repos/plywood/src/build/target/ply-build-target/Dependency.h
@@ -73,6 +73,7 @@ struct BuildTarget {
     String dynamicLinkPrefix;
     Array<SourceFilesPair> sourceFiles;
     Array<SourceFilesPair> sourceFilesWhenImported;
+    Array<SourceFilesPair> nonParticipatingFiles;
     Array<String> privateIncludeDirs;
     Array<PreprocessorDefinition> privateDefines;
     Array<String> privateAbstractFlags;
@@ -85,6 +86,8 @@ struct BuildTarget {
     PLY_BUILD_ENTRY void addSourceFiles(StringView absSourcePath, bool recursive = true);
     PLY_BUILD_ENTRY void addSourceFilesWhenImported(StringView absSourceRoot,
                                                   ArrayView<const StringView> relPaths);
+    PLY_BUILD_ENTRY void addNonParticipatingFiles(StringView absSourceRoot, ArrayView<const StringView> relPaths);
+
     // Returns false if absGeneratorSource is not a source file:
     PLY_BUILD_ENTRY bool setPrecompiledHeader(StringView absGeneratorSource, StringView pchInclude);
     PLY_BUILD_ENTRY bool setPreprocessorDefinition(Visibility visibility, StringView key,

--- a/repos/plywood/src/build/target/ply-build-target/ply-build-target.natvis
+++ b/repos/plywood/src/build/target/ply-build-target/ply-build-target.natvis
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+  <Type Name="ply::Dependency">
+    <DisplayString>{key}</DisplayString>
+  </Type>
+</AutoVisualizer>

--- a/repos/plywood/src/math/math/ply-math/ply-math.natvis
+++ b/repos/plywood/src/math/math/ply-math/ply-math.natvis
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+  <Type Name="ply::Float2">
+    <DisplayString>{{{x,g}, {y,g}}}</DisplayString>
+  </Type>
+
+  <Type Name="ply::Float3">
+    <DisplayString>{{{x,g}, {y,g}, {z,g}}}</DisplayString>
+  </Type>
+
+  <Type Name="ply::Float4">
+    <DisplayString>{{{x,f}, {y,f}, {z,f}, {w,f}}}</DisplayString>
+  </Type>
+
+  <Type Name="ply::Quaternion">
+    <DisplayString>{{{x,g}, {y,g}, {z,g}, {w,g}}}</DisplayString>
+  </Type>
+
+  <Type Name="ply::Int2&lt;*&gt;">
+    <DisplayString>{{{x}, {y}}}</DisplayString>
+  </Type>
+
+  <Type Name="ply::Float3x3">
+    <DisplayString>col[2]={col[2]}</DisplayString>
+    <Expand>
+      <ExpandedItem>col</ExpandedItem>
+    </Expand>
+  </Type>
+
+  <Type Name="ply::Float3x4">
+    <DisplayString>col[3]={col[3]}</DisplayString>
+    <Expand>
+      <ExpandedItem>col</ExpandedItem>
+    </Expand>
+  </Type>
+
+  <Type Name="ply::Float4x4">
+    <DisplayString>col[3]={col[3]}</DisplayString>
+    <Expand>
+      <ExpandedItem>col</ExpandedItem>
+    </Expand>
+  </Type>
+</AutoVisualizer>

--- a/repos/plywood/src/reflect/ply-reflect/ply-reflect.natvis
+++ b/repos/plywood/src/reflect/ply-reflect/ply-reflect.natvis
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+  <Type Name="ply::TypedPtr">
+    <DisplayString>{{ptr={ptr} type={*type}}}</DisplayString>
+  </Type>
+
+  <Type Name="ply::TypeDescriptor">
+    <DisplayString Condition="typeKey == &amp;ply::TypeKey_Struct">[TypeDescriptor_Struct] {((ply::TypeDescriptor_Struct*) this)->name}</DisplayString>
+    <DisplayString Condition="typeKey != &amp;ply::TypeKey_Struct">{(void*) typeKey}</DisplayString>
+    <Expand>
+      <ExpandedItem Condition="typeKey == &amp;ply::TypeKey_Struct">(ply::TypeDescriptor_Struct*) this,!</ExpandedItem>
+      <ExpandedItem Condition="typeKey != &amp;ply::TypeKey_Struct">this</ExpandedItem>
+    </Expand>
+  </Type>
+</AutoVisualizer>

--- a/repos/plywood/src/runtime/ply-runtime/ply-runtime.natvis
+++ b/repos/plywood/src/runtime/ply-runtime/ply-runtime.natvis
@@ -175,19 +175,6 @@
     </Expand>
   </Type>
 
-  <Type Name="ply::TypedPtr">
-    <DisplayString>{{ptr={ptr} type={*type}}}</DisplayString>
-  </Type>
-
-  <Type Name="ply::TypeDescriptor">
-    <DisplayString Condition="typeKey == &amp;ply::TypeKey_Struct">[TypeDescriptor_Struct] {((ply::TypeDescriptor_Struct*) this)->name}</DisplayString>
-    <DisplayString Condition="typeKey != &amp;ply::TypeKey_Struct">{(void*) typeKey}</DisplayString>
-    <Expand>
-      <ExpandedItem Condition="typeKey == &amp;ply::TypeKey_Struct">(ply::TypeDescriptor_Struct*) this,!</ExpandedItem>
-      <ExpandedItem Condition="typeKey != &amp;ply::TypeKey_Struct">this</ExpandedItem>
-    </Expand>
-  </Type>
-
   <Type Name="ply::BTree&lt;*&gt;::Node">
     <DisplayString>size={size} isLeaf={isLeaf}</DisplayString>
     <Expand>
@@ -225,77 +212,10 @@
     </Expand>
   </Type>
 
-  <Type Name="session::SessionDescriptor">
-    <DisplayString>{name,s}</DisplayString>
-  </Type>
-
-  <Type Name="session::Session">
-    <DisplayString>{{ptr={ptr} desc={*desc}}}</DisplayString>
-  </Type>
-
   <Type Name="ply::Reference&lt;*&gt;">
     <DisplayString>{m_ptr}</DisplayString>
     <Expand>
       <ExpandedItem>m_ptr</ExpandedItem>
     </Expand>
-  </Type>
-
-  <Type Name="ply::Float2">
-    <DisplayString>{{{x,g}, {y,g}}}</DisplayString>
-  </Type>
-
-  <Type Name="ply::Float3">
-    <DisplayString>{{{x,g}, {y,g}, {z,g}}}</DisplayString>
-  </Type>
-
-  <Type Name="ply::Float4">
-    <DisplayString>{{{x,f}, {y,f}, {z,f}, {w,f}}}</DisplayString>
-  </Type>
-
-  <Type Name="ply::Quaternion">
-    <DisplayString>{{{x,g}, {y,g}, {z,g}, {w,g}}}</DisplayString>
-  </Type>
-
-  <Type Name="ply::Int2&lt;*&gt;">
-    <DisplayString>{{{x}, {y}}}</DisplayString>
-  </Type>
-
-  <Type Name="ply::Float3x3">
-    <DisplayString>col[2]={col[2]}</DisplayString>
-    <Expand>
-      <ExpandedItem>col</ExpandedItem>
-    </Expand>
-  </Type>
-
-  <Type Name="ply::Float3x4">
-    <DisplayString>col[3]={col[3]}</DisplayString>
-    <Expand>
-      <ExpandedItem>col</ExpandedItem>
-    </Expand>
-  </Type>
-
-  <Type Name="ply::Float4x4">
-    <DisplayString>col[3]={col[3]}</DisplayString>
-    <Expand>
-      <ExpandedItem>col</ExpandedItem>
-    </Expand>
-  </Type>
-
-  <Type Name="alton::Node">
-    <DisplayString Condition="type.id == alton::Node::Type::ID::Object">Object [{((alton::Node::Type::Object*) type.buf)->map.m_population,d} items]</DisplayString>
-    <DisplayString Condition="type.id == alton::Node::Type::ID::Text">Text {((alton::Node::Type::Text*) type.buf)->str}</DisplayString>
-    <DisplayString Condition="type.id == alton::Node::Type::ID::Array">Array [{((alton::Node::Type::Array*) type.buf)->arr.numItems_,d} items]</DisplayString>
-    <Expand>
-      <ExpandedItem Condition="type.id == alton::Node::Type::ID::Object">((alton::Node::Type::Object*) type.buf)->map</ExpandedItem>
-      <ExpandedItem Condition="type.id == alton::Node::Type::ID::Array">((alton::Node::Type::Array*) type.buf)->arr</ExpandedItem>
-    </Expand>
-  </Type>
-
-  <Type Name="ply::DependencyKey">
-    <DisplayString>{repo->repoName} {depType,en} {name} {dllBeh}</DisplayString>
-  </Type>
-
-  <Type Name="ply::Dependency">
-    <DisplayString>{key}</DisplayString>
   </Type>
 </AutoVisualizer>


### PR DESCRIPTION
Non participating files are added to the Visual Studio project, but are not compiled. This is useful for having the `.modules.cpp` in the project, but also for adding `.natvis` files (and perhaps other things in the future).

Files can be added manually with `ModuleArgs::addNonParticipatingFiles`, but .modules.cpp and .natvis files are also automatically added as non-participating by `ModuleArgs::addSourceFiles` now (previously they were just ignored).

I also moved/split the natvis definitions to per module files so that you automatically get the natvis file in your solution when you use that module. There are a few types that are not (anymore?) in plywood so I removed them, but if you prefer I can also re-add them somewhere. The types in question:
- session::SessionDescriptor
- session::Session
- ply::DependencyKey
- alton::Node
